### PR TITLE
Add GitHub Actions workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  lints:
+    name: Format & Clippy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+          profile: minimal
+          overwrite: true
+
+      - run: cargo fmt -- --check
+      - run: cargo clippy
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          overwrite: true
+
+      - run: cargo test

--- a/src/responders.rs
+++ b/src/responders.rs
@@ -125,9 +125,7 @@ where
             resp
         }
         let mut builder = http::Response::builder();
-        builder = builder
-            .status(self.status().clone())
-            .version(self.version().clone());
+        builder = builder.status(self.status()).version(self.version());
         *builder.headers_mut().unwrap() = self.headers().clone();
         let resp = builder.body(self.body().clone().into()).unwrap();
 

--- a/src/server_pool.rs
+++ b/src/server_pool.rs
@@ -67,6 +67,7 @@ impl ServerPool {
     }
 }
 
+#[allow(clippy::mutex_atomic)]
 #[derive(Debug)]
 struct InnerPool {
     servers_created: Mutex<usize>,
@@ -74,6 +75,7 @@ struct InnerPool {
     servers_rx: crossbeam_channel::Receiver<Server>,
 }
 
+#[allow(clippy::mutex_atomic)]
 impl InnerPool {
     fn new(max_capacity: usize) -> Self {
         assert!(max_capacity > 0);
@@ -116,6 +118,7 @@ impl InnerPool {
     }
 }
 
+#[allow(clippy::mutex_atomic)]
 impl Drop for InnerPool {
     fn drop(&mut self) {
         // wait for all created servers to get returned to the pool.


### PR DESCRIPTION
The PR adds two build jobs for fmt/clippy & test and fixes two clippy warnings

fix `clippy::clone_on_copy`
allow `clippy::mutex_atomic`

[Result](https://github.com/nickelc/httptest/actions/runs/337515330)