### PR TITLE
Update dependencies and tune the features in use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ no-dev-version = true
 [dependencies]
 bytes = "1.0"
 hyper = { version = "0.14", features = ["http1", "http2", "server", "tcp"] }
-futures = "0.3"
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-crossbeam-channel = "0.4.0"
+futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
+tokio = { version = "1.0", features = ["rt-multi-thread"] }
+crossbeam-channel = "0.5.0"
 http = "0.2"
 log = "0.4.8"
 bstr = "0.2.8"
@@ -33,5 +33,6 @@ once_cell = "1.2.0"
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }
 pretty_env_logger = "0.4"
-crossbeam-utils = "0.7.0"
+crossbeam-utils = "0.8.1"
 serde = { version = "1", features = ["derive"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
`futures-executor` is no longer pulled in via `futures`.