### PR TITLE
Check if thread is panicking before unwraping LockResult

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -46,6 +46,21 @@ async fn test_expectation_cardinality_not_reached() {
 
 #[tokio::test]
 #[should_panic]
+async fn test_expectation_cardinality_not_reached_explicit_verify() {
+    let _ = pretty_env_logger::try_init();
+
+    // Setup a server to expect a single GET /foo request.
+    let mut server = httptest::Server::run();
+    server.expect(
+        Expectation::matching(all_of![request::method("GET"), request::path("/foo")])
+            .respond_with(status_code(200)),
+    );
+
+    server.verify_and_clear();
+}
+
+#[tokio::test]
+#[should_panic]
 async fn test_expectation_cardinality_exceeded() {
     let _ = pretty_env_logger::try_init();
 


### PR DESCRIPTION
Calling `verify_and_clear` may cause a panic and poison the httptest's internal mutex. When unwinding, the httptest calls `verify_and_clear` again which leads to a panic in a panic caused by a poisoned mutex. All that results in a process exit with signal 4 (SIGILL).

@ggriffiniii would it be possible to backport this to `0.13.x`?