### PR TITLE
Add IPv6 support

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,10 @@
 use crate::matchers::{matcher_name, ExecutionContext, Matcher};
 use crate::responders::Responder;
+use futures::future::FutureExt;
+use hyper::{
+    service::{make_service_fn, service_fn},
+    Error,
+};
 use std::fmt;
 use std::future::Future;
 use std::net::SocketAddr;
@@ -20,17 +25,29 @@ pub struct Server {
 }
 
 impl Server {
-    /// Start a server.
+    /// Start a IPv4 server.
     ///
     /// The server will run in the background. On Drop it will terminate and
     /// assert it's expectations.
     pub fn run() -> Self {
-        use futures::future::FutureExt;
-        use hyper::{
-            service::{make_service_fn, service_fn},
-            Error,
-        };
         let bind_addr = ([127, 0, 0, 1], 0).into();
+        Self::from_addr(bind_addr)
+    }
+
+    /// Start a IPv6 server.
+    ///
+    /// The server will run in the background. On Drop it will terminate and
+    /// assert it's expectations.
+    pub fn run_ipv6() -> Self {
+        let bind_addr = ([0, 0, 0, 0, 0, 0, 0, 1], 0).into();
+        Self::from_addr(bind_addr)
+    }
+
+    /// Start a server bound to an address specified by `bind_addr`.
+    ///
+    /// The server will run in the background. On Drop it will terminate and
+    /// assert it's expectations.
+    pub fn from_addr(bind_addr: SocketAddr) -> Self {
         // And a MakeService to handle each connection...
         let state = ServerState::default();
         let make_service = make_service_fn({

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,62 +33,14 @@ impl Server {
         let ipv6_bind_addr: SocketAddr = ([0, 0, 0, 0, 0, 0, 0, 1], 0).into();
         let ipv4_bind_addr: SocketAddr = ([127, 0, 0, 1], 0).into();
 
-        let state = ServerState::default();
-        let make_service = make_service_fn({
-            let state = state.clone();
-            move |_| {
-                let state = state.clone();
-                async move {
-                    let state = state.clone();
-                    Ok::<_, Error>(service_fn({
-                        move |req: http::Request<hyper::Body>| {
-                            let state = state.clone();
-                            async move { process_request(state, req).await }
-                        }
-                    }))
-                }
-            }
-        });
-
-        let listener = TcpListener::bind(ipv6_bind_addr).unwrap_or_else(|_| {
-            log::debug!("bind to ipv6 failed, trying ipv4 instead");
-            TcpListener::bind(ipv4_bind_addr).unwrap()
-        });
-
-        let addr = listener.local_addr().unwrap();
-
-        // Then bind and serve...
-        let (trigger_shutdown, shutdown_received) = futures::channel::oneshot::channel();
-        let join_handle = std::thread::spawn(move || {
-            let runtime = tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(1)
-                .enable_all()
-                .build()
-                .unwrap();
-            runtime.block_on(async move {
-                let server = hyper::Server::from_tcp(listener)
-                    .unwrap()
-                    .serve(make_service);
-
-                futures::select! {
-                    _ = server.fuse() => {},
-                    _ = shutdown_received.fuse() => {},
-                }
-            });
-        });
-        Server {
-            trigger_shutdown: Some(trigger_shutdown),
-            join_handle: Some(join_handle),
-            addr,
-            state,
-        }
+        Self::run_http(ipv6_bind_addr).unwrap_or_else(|_| Self::run_http(ipv4_bind_addr).unwrap())
     }
 
     /// Start a server bound to an address specified by `bind_addr`.
     ///
     /// The server will run in the background. On Drop it will terminate and
     /// assert it's expectations.
-    pub fn run_http(bind_addr: SocketAddr) -> Self {
+    pub fn run_http(bind_addr: SocketAddr) -> std::io::Result<Self> {
         // And a MakeService to handle each connection...
         let state = ServerState::default();
         let make_service = make_service_fn({
@@ -106,7 +58,10 @@ impl Server {
                 }
             }
         });
-        let (addr_tx, addr_rx) = crossbeam_channel::unbounded();
+
+        let listener = TcpListener::bind(bind_addr)?;
+        let addr = listener.local_addr()?;
+
         // Then bind and serve...
         let (trigger_shutdown, shutdown_received) = futures::channel::oneshot::channel();
         let join_handle = std::thread::spawn(move || {
@@ -115,22 +70,24 @@ impl Server {
                 .enable_all()
                 .build()
                 .unwrap();
+
             runtime.block_on(async move {
-                let server = hyper::Server::bind(&bind_addr).serve(make_service);
-                addr_tx.send(server.local_addr()).unwrap();
+                let server = hyper::Server::from_tcp(listener)
+                    .unwrap()
+                    .serve(make_service);
                 futures::select! {
                     _ = server.fuse() => {},
                     _ = shutdown_received.fuse() => {},
                 }
             });
         });
-        let addr = addr_rx.recv().unwrap();
-        Server {
+
+        Ok(Server {
             trigger_shutdown: Some(trigger_shutdown),
             join_handle: Some(join_handle),
             addr,
             state,
-        }
+        })
     }
 
     /// Get the address the server is listening on.

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,7 @@ use hyper::{
 };
 use std::fmt;
 use std::future::Future;
-use std::net::SocketAddr;
+use std::net::{SocketAddr, TcpListener};
 use std::ops::{Bound, RangeBounds};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -30,8 +30,8 @@ impl Server {
     /// The server will run in the background. On Drop it will terminate and
     /// assert it's expectations.
     pub fn run() -> Self {
-        let ipv6_bind_addr = ([0, 0, 0, 0, 0, 0, 0, 1], 0).into();
-        let ipv4_bind_addr = ([127, 0, 0, 1], 0).into();
+        let ipv6_bind_addr: SocketAddr = ([0, 0, 0, 0, 0, 0, 0, 1], 0).into();
+        let ipv4_bind_addr: SocketAddr = ([127, 0, 0, 1], 0).into();
 
         let state = ServerState::default();
         let make_service = make_service_fn({
@@ -49,7 +49,14 @@ impl Server {
                 }
             }
         });
-        let (addr_tx, addr_rx) = crossbeam_channel::unbounded();
+
+        let listener = TcpListener::bind(ipv6_bind_addr).unwrap_or_else(|_| {
+            log::debug!("bind to ipv6 failed, trying ipv4 instead");
+            TcpListener::bind(ipv4_bind_addr).unwrap()
+        });
+
+        let addr = listener.local_addr().unwrap();
+
         // Then bind and serve...
         let (trigger_shutdown, shutdown_received) = futures::channel::oneshot::channel();
         let join_handle = std::thread::spawn(move || {
@@ -59,18 +66,16 @@ impl Server {
                 .build()
                 .unwrap();
             runtime.block_on(async move {
-                let server = hyper::Server::try_bind(&ipv6_bind_addr)
-                    .unwrap_or_else(|_| hyper::Server::bind(&ipv4_bind_addr))
+                let server = hyper::Server::from_tcp(listener)
+                    .unwrap()
                     .serve(make_service);
 
-                addr_tx.send(server.local_addr()).unwrap();
                 futures::select! {
                     _ = server.fuse() => {},
                     _ = shutdown_received.fuse() => {},
                 }
             });
         });
-        let addr = addr_rx.recv().unwrap();
         Server {
             trigger_shutdown: Some(trigger_shutdown),
             join_handle: Some(join_handle),

--- a/src/server.rs
+++ b/src/server.rs
@@ -144,12 +144,12 @@ impl Server {
         let mut state = state.expect("mutex poisoned");
         for expectation in state.expected.iter() {
             if !hit_count_is_valid(expectation.times, expectation.hit_count) {
-                panic!(format!(
+                panic!(
                     "Unexpected number of requests for matcher '{:?}'; received {}; expected {}",
                     matcher_name(&*expectation.matcher),
                     expectation.hit_count,
                     RangeDisplay(expectation.times),
-                ));
+                );
             }
         }
         if !state.unexpected_requests.is_empty() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -330,13 +330,13 @@ fn test_outside_of_tokio_context() {
 }
 
 #[tokio::test]
-async fn test_server_from_addr() {
+async fn test_server_run_http() {
     let _ = pretty_env_logger::try_init();
 
     let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
     // Setup a server to expect a single GET /foo request.
-    let server = httptest::Server::from_addr(bind_addr);
+    let server = httptest::Server::run_http(bind_addr);
     server.expect(
         Expectation::matching(all_of![request::method("GET"), request::path("/foo")])
             .respond_with(status_code(200)),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,5 @@
 use httptest::{matchers::*, responders::*, Expectation};
-use std::future::Future;
+use std::{future::Future, net::SocketAddr};
 
 async fn read_response_body(
     resp_fut: impl Future<Output = Result<hyper::Response<hyper::Body>, hyper::Error>>,
@@ -327,4 +327,25 @@ async fn test_readme() {
 fn test_outside_of_tokio_context() {
     let _ = pretty_env_logger::try_init();
     let _server = httptest::Server::run();
+}
+
+#[tokio::test]
+async fn test_server_from_addr() {
+    let _ = pretty_env_logger::try_init();
+
+    let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+
+    // Setup a server to expect a single GET /foo request.
+    let server = httptest::Server::from_addr(bind_addr);
+    server.expect(
+        Expectation::matching(all_of![request::method("GET"), request::path("/foo")])
+            .respond_with(status_code(200)),
+    );
+
+    // Issue the GET /foo to the server and verify it returns a 200.
+    let client = hyper::Client::new();
+    let resp = read_response_body(client.get(server.url("/foo"))).await;
+    assert_eq!(200, resp.status().as_u16());
+
+    // The Drop impl of the server will assert that all expectations were satisfied or else it will panic.
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -336,7 +336,7 @@ async fn test_server_run_http() {
     let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
     // Setup a server to expect a single GET /foo request.
-    let server = httptest::Server::run_http(bind_addr);
+    let server = httptest::Server::run_http(bind_addr).unwrap();
     server.expect(
         Expectation::matching(all_of![request::method("GET"), request::path("/foo")])
             .respond_with(status_code(200)),


### PR DESCRIPTION
Couldn't really add a test because it'd fail on systems with ipv6 stack disabled e.g. my desktop (it did work fine on my laptop) - if you know a portable way to check for ipv6 support then I'll add one.

Also, would you consider adding https support?