### PR TITLE
Fix a package name in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ running http server. The typical usage is as follows:
 ```rust
 #[tokio::test]
 async fn test_readme() {
-    use httptest::{mappers::*, responders::*, Expectation, Server};
+    use httptest::{matchers::*, responders::*, Expectation, Server};
     use serde_json::json;
     // Starting a logger within the test can make debugging a failed test
     // easier. The mock http server will log::debug every request and response


### PR DESCRIPTION
I noticed that the README.md sample did not follow 75a4d7b2ef0fcac758ae55b54347782c65ebb50e.