### PR TITLE
Update dependencies - hyper 1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,24 +12,27 @@ readme = "README.md"
 keywords = ["http", "test", "testing", "mock", "fake"]
 
 [dependencies]
-bytes = "1.0"
-hyper = { version = "0.14", features = ["http1", "http2", "server", "tcp"] }
+bytes = "1.6"
+hyper = { version = "1.2", features = ["http1", "http2", "server"] }
+hyper-util = { version = "0.1", features = ["http1", "http2", "server", "tokio"] }
+http-body-util = "0.1"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
-tokio = { version = "1.0", features = ["rt-multi-thread", "time"] }
-crossbeam-channel = "0.5.0"
-http = "0.2"
-log = "0.4.8"
-bstr = "0.2.8"
-regex = "1.3.1"
-form_urlencoded = "1.0"
-serde_json = "1.0.44"
+tokio = { version = "1.37", features = ["rt-multi-thread", "time"] }
+crossbeam-channel = "0.5.12"
+http = "1.1"
+log = "0.4.21"
+bstr = "1.9.1"
+regex = "1.10.4"
+form_urlencoded = "1.2"
+serde_json = "1.0"
 serde = "1"
 serde_urlencoded = "0.7"
-once_cell = "1.2.0"
+once_cell = "1.19.0"
 
 [dev-dependencies]
-hyper = { version = "0.14", features = ["full"] }
-pretty_env_logger = "0.4"
-crossbeam-utils = "0.8.1"
+hyper = { version = "1.2", features = ["full"] }
+hyper-util = { version = "0.1", features = ["http1", "http2", "client", "tokio", "client-legacy"] }
+pretty_env_logger = "0.5"
+crossbeam-utils = "0.8.19"
 serde = { version = "1", features = ["derive"] }
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.37", features = ["macros", "rt-multi-thread"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ running http server. The typical usage is as follows:
 
 ```
 # async fn foo() {
+use http_body_util::Full;
+use hyper_util::client::legacy::Client;
 use httptest::{Server, Expectation, matchers::*, responders::*};
 // Start a server running on a local ephemeral port.
 let server = Server::run();
@@ -27,7 +29,7 @@ server.expect(
 // locally running server, or more conveniently provides a server.url() method
 // that gives a fully formed http url to the provided path.
 let url = server.url("/foo");
-let client = hyper::Client::new();
+let client = Client::builder(hyper_util::rt::TokioExecutor::new()).build_http::<Full<bytes::Bytes>>();
 // Issue the GET /foo to the server.
 let resp = client.get(url).await.unwrap();
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -372,7 +372,7 @@ impl ServerBuilder {
         let service = |state: ServerState| {
             service_fn(move |req: http::Request<hyper::body::Incoming>| {
                 let state = state.clone();
-                async move { process_request(state, req).await }
+                process_request(state, req)
             })
         };
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -398,9 +398,8 @@ impl ServerBuilder {
                         let state_c = state_listener.clone();
                         let (stream, _addr) = match listener.accept().await {
                             Ok(a) => a,
-                            Err(_e) => {
-                                log::warn!("listener failed to accept a new connection");
-                                continue;
+                            Err(e) => {
+                                panic!("listener failed to accept a new connection: {}", e);
                             }
                         };
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -121,7 +121,7 @@ async fn process_request(
     let body = Full::new(body).boxed();
     let resp = hyper::Response::from_parts(parts, body);
 
-    // log::debug!("Sending Response: {:?}", resp);
+    log::debug!("Sending Response: {:?}", resp);
     hyper::Result::Ok(resp)
 }
 

--- a/src/server_pool.rs
+++ b/src/server_pool.rs
@@ -34,7 +34,7 @@ use std::sync::Mutex;
 ///     let server = SERVER_POOL.get_server();
 ///     server.expect(Expectation::matching(any()).respond_with(status_code(200)));
 ///     // invoke http requests to server.
-///     
+///
 ///     // server will assert expectations are met on drop.
 /// }
 ///
@@ -43,7 +43,7 @@ use std::sync::Mutex;
 ///     let server = SERVER_POOL.get_server();
 ///     server.expect(Expectation::matching(any()).respond_with(status_code(200)));
 ///     // invoke http requests to server.
-///     
+///
 ///     // server will assert expectations are met on drop.
 /// }
 /// ```


### PR DESCRIPTION
There's a bunch of stuff that changed with hyper 1.0 - server got removed, client got removed but is still available under hyper-util crate, hyper::Body is now a trait, etc. I went down the path of least resistance to update the hyper dependency so if you think the approach taken in this MR is not quite what you want for this crate, feel free to close it, or use as a base for future improvements.

Closes #21 