### PR TITLE
Log unexpected requests when a matcher fails

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -78,14 +78,22 @@ impl Server {
         }
         for expectation in state.expected.iter() {
             if !hit_count_is_valid(expectation.times, expectation.hit_count) {
+                let unexpected_requests_message = if state.unexpected_requests.is_empty() {
+                    "(no other unexpected requests)".to_string()
+                } else {
+                    format!(
+                        "There were {} other unexpected requests that you may have expected to match: {:#?}",
+                        state.unexpected_requests.len(),
+                        &state.unexpected_requests,
+                    )
+                };
+
                 panic!(
-                    "Unexpected number of requests for matcher '{:?}'; received {}; expected {}. \
-                    There were {} other unexpected requests that you may have expected to match: {:#?}",
+                    "Unexpected number of requests for matcher '{:?}'; received {}; expected {}. {}",
                     matcher_name(&*expectation.matcher),
                     expectation.hit_count,
                     RangeDisplay(expectation.times),
-                    state.unexpected_requests.len(),
-                    &state.unexpected_requests,
+                    unexpected_requests_message,
                 );
             }
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -79,10 +79,13 @@ impl Server {
         for expectation in state.expected.iter() {
             if !hit_count_is_valid(expectation.times, expectation.hit_count) {
                 panic!(
-                    "Unexpected number of requests for matcher '{:?}'; received {}; expected {}",
+                    "Unexpected number of requests for matcher '{:?}'; received {}; expected {}. \
+                    There were {} other unexpected requests that you may have expected to match: {:#?}",
                     matcher_name(&*expectation.matcher),
                     expectation.hit_count,
                     RangeDisplay(expectation.times),
+                    state.unexpected_requests.len(),
+                    &state.unexpected_requests,
                 );
             }
         }


### PR DESCRIPTION
Log unexpected requests when a matcher fails as those "unexpected" requests could easily be the request you're expecting but your matcher is wrong or too strict. It's hard to debug these scenarios without this extra information.


Before:

```
Unexpected number of requests for matcher 'AllOf[MethodPath { method: "POST", path: "/request-checker" }, Headers(Contains(("content-type", "application/json"))), Body(JsonDecoded(Eq(Object {"body": Object {"data": String("{\"foo\": \"bar\"}"), "format": String("text")}, "destination_uri": String("http://localhost/_matrix/client/v3/rooms/!myroomid/invite"), "headers": Object {"X-Test-Header": String("test")}, "method": String("POST")})))]'; received 0; expected Exactly(1)
```

After:

```
thread 'tests::should_pass_requests_to_proxy_url' panicked at /home/eric/Documents/github/httptest/src/server.rs:81:17:
Unexpected number of requests for matcher 'AllOf[MethodPath { method: "POST", path: "/request-checker" }, Headers(Contains(("content-type", "application/json"))), Body(JsonDecoded(Eq(Object {"body": Object {"data": String("{\"foo\": \"bar\"}"), "format": String("text")}, "destination_uri": String("http://localhost/_matrix/client/v3/rooms/!myroomid/invite"), "headers": Object {"x-forwarded-for": String("127.0.0.1"), "x-test-header": String("test")}, "method": String("POST")})))]'; received 0; expected Exactly(1). There were 1 other unexpected requests that you may have expected to match: [
    Request {
        method: POST,
        uri: /request-checker,
        version: HTTP/1.1,
        headers: {
            "content-type": "application/json",
            "accept": "application/json",
            "host": "127.0.0.1:35535",
            "content-length": "212",
        },
        body: b"{\"method\":\"POST\",\"destination_uri\":\"http://localhost/_matrix/client/v3/rooms/!myroomid/invite\",\"headers\":{\"x-test-header\":\"test\",\"x-forwarded-for\":\"127.0.0.1\"},\"body\":{\"format\":\"text\",\"data\":\"{\\\"foo\\\":\\\"bar\\\"}\"}}",
    },
]
```


### Dev notes

Related to https://github.com/ggriffiniii/httptest/issues/26