### PR TITLE
Re-export `hyper` so you can implement a `Responder` without having to install anything extra

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,6 +351,7 @@ macro_rules! vec_of_boxes {
 // re-exports of types from dependent crates that show up in the public api.
 pub use bytes;
 pub use http;
+pub use hyper;
 
 mod into_times;
 pub mod matchers;


### PR DESCRIPTION
Re-export `hyper` so you can implement a [`Responder`](https://github.com/ggriffiniii/httptest/blob/7143f1b2578dda0efd226b16625dfbb4697a168b/src/responders.rs#L25-L32) without having to install anything extra.

